### PR TITLE
Fix path to scisql_index in documentation

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -541,7 +541,7 @@ SELECT scienceCcdExposureId,
                 Then, run the sciSQL region indexing utility:
         </p>
         <pre class="prettyprint lang-bash linenums">
-${MYSQL_DIR}/bin/scisql_index -l 10 /tmp/scisql_demo_htmid10.tsv /tmp/scisql_demo_ccds.tsv</pre>
+scisql_index -l 10 /tmp/scisql_demo_htmid10.tsv /tmp/scisql_demo_ccds.tsv</pre>
         <p>
                 and load the results:
         </p>

--- a/tools/templates/sections.xml
+++ b/tools/templates/sections.xml
@@ -425,7 +425,7 @@ SELECT scienceCcdExposureId,
                 Then, run the sciSQL region indexing utility:
         </p>
         <example lang="bash">
-$${MYSQL_DIR}/bin/scisql_index -l 10 /tmp/scisql_demo_htmid10.tsv /tmp/scisql_demo_ccds.tsv</example>
+scisql_index -l 10 /tmp/scisql_demo_htmid10.tsv /tmp/scisql_demo_ccds.tsv</example>
         <p>
                 and load the results:
         </p>


### PR DESCRIPTION
In order be get eups-compliant, scisql_index is
installed by default in scisql_prefix/bin.
Documentation has been updated w.r.t. this.
Tests, which are launching documentation extracts,
are now passed successfully.
