### PR TITLE
Couple of small fixes for Python3 support.

### DIFF
--- a/python/scisql/utils.py
+++ b/python/scisql/utils.py
@@ -25,7 +25,10 @@ def run_command(cmd_args, loglevel=logging.INFO) :
 
     try:
 
-        process = subprocess.Popen(cmd_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        # universal_newlines=True is to make sure that pipes are open in text mode
+        # to make it return strings in Python3 using Python2-compatible API
+        process = subprocess.Popen(cmd_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                   universal_newlines=True)
 
         def logstream(stream, loggercb):
             while True:

--- a/tools/docs.py
+++ b/tools/docs.py
@@ -424,7 +424,7 @@ def _test(obj):
     for ex in obj.examples:
         if not ex.test or ex.lang not in ('sql', 'bash'):
             continue
-        with tempfile.TemporaryFile() as source:
+        with tempfile.TemporaryFile("w+t") as source:
             if ex.lang == 'sql':
                 source.write('USE scisql_demo;\n\n')
                 args = [os.environ['MYSQL'], '--defaults-file=%s' % os.environ['MYSQL_CNF']]


### PR DESCRIPTION
Makes sure that files, such as pipes and temporary files, are open in
text mode so that we read strings and not bytes in Py3.