### PR TITLE
Fix Python xml.etree API compato in docs.py

### DIFF
--- a/tools/docs.py
+++ b/tools/docs.py
@@ -306,7 +306,7 @@ class Section(object):
         self.udfs = []
         self.procs = []
         # Extract example source code
-        exlist = list(elt.getiterator('example'))
+        exlist = list(elt.iter('example'))
         self.examples = [Example(x) for x in exlist]
         # Turn <example> tags into <pre> tags with the appropriate prettify attributes
         for ex in exlist:


### PR DESCRIPTION
Rubin recently updated the conda env being used for Qserv "classic" builds -- this caused build breakage due to use of deprecated API `xml.etree.ElementTree.Element.getiterator` in the `docs.py` script (see https://docs.python.org/3.8/library/xml.etree.elementtree.html#xml.etree.ElementTree.Element.getiterator.)

Trivial change to use the non-deprecated version instead, which has been around since 2.7.