### PR TITLE
Update copyright headers

### DIFF
--- a/python/scisql/configure.py
+++ b/python/scisql/configure.py
@@ -1,3 +1,26 @@
+#! /usr/bin/env python
+# encoding: utf-8
+#
+# Copyright (C) 2011-2022 the SciSQL authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors:
+#     - Serge Monkewitz, IPAC/Caltech
+#
+# Work on this project has been sponsored by LSST and SLAC/DOE.
+#
+
 from scisql import const
 import logging
 import os

--- a/python/scisql/utils.py
+++ b/python/scisql/utils.py
@@ -1,3 +1,26 @@
+#! /usr/bin/env python
+# encoding: utf-8
+#
+# Copyright (C) 2011-2022 the SciSQL authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors:
+#     - Serge Monkewitz, IPAC/Caltech
+#
+# Work on this project has been sponsored by LSST and SLAC/DOE.
+#
+
 from distutils.util import strtobool
 import logging
 from threading import Thread

--- a/src/common.h
+++ b/src/common.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2011 Serge Monkewitz
+    Copyright (C) 2011-2022 the SciSQL authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/geometry.c
+++ b/src/geometry.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2011 Serge Monkewitz
+    Copyright (C) 2011-2022 the SciSQL authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/geometry.h
+++ b/src/geometry.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2011 Serge Monkewitz
+    Copyright (C) 2011-2022 the SciSQL authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/htm.c
+++ b/src/htm.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2011 Serge Monkewitz
+    Copyright (C) 2011-2022 the SciSQL authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/htm.h
+++ b/src/htm.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2011 Serge Monkewitz
+    Copyright (C) 2011-2022 the SciSQL authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/photometry.h
+++ b/src/photometry.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2011 Serge Monkewitz
+    Copyright (C) 2011-2022 the SciSQL authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/select.c
+++ b/src/select.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2011 Serge Monkewitz
+    Copyright (C) 2011-2022 the SciSQL authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/select.h
+++ b/src/select.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2011 Serge Monkewitz
+    Copyright (C) 2011-2022 the SciSQL authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/udf.h
+++ b/src/udf.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2011 Serge Monkewitz
+    Copyright (C) 2011-2022 the SciSQL authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/udfs/abMagToDn.c
+++ b/src/udfs/abMagToDn.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2011 Serge Monkewitz
+    Copyright (C) 2011-2022 the SciSQL authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/udfs/abMagToDnSigma.c
+++ b/src/udfs/abMagToDnSigma.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2011 Serge Monkewitz
+    Copyright (C) 2011-2022 the SciSQL authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/udfs/abMagToFlux.c
+++ b/src/udfs/abMagToFlux.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2011 Serge Monkewitz
+    Copyright (C) 2011-2022 the SciSQL authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/udfs/abMagToFluxSigma.c
+++ b/src/udfs/abMagToFluxSigma.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2011 Serge Monkewitz
+    Copyright (C) 2011-2022 the SciSQL authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/udfs/abMagToNanojansky.c
+++ b/src/udfs/abMagToNanojansky.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2011 Serge Monkewitz
+    Copyright (C) 2011-2022 the SciSQL authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/udfs/abMagToNanojanskySigma.c
+++ b/src/udfs/abMagToNanojanskySigma.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2011 Serge Monkewitz
+    Copyright (C) 2011-2022 the SciSQL authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/udfs/angSep.c
+++ b/src/udfs/angSep.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2011 Serge Monkewitz
+    Copyright (C) 2011-2022 the SciSQL authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/udfs/dnToAbMag.c
+++ b/src/udfs/dnToAbMag.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2011 Serge Monkewitz
+    Copyright (C) 2011-2022 the SciSQL authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/udfs/dnToAbMagSigma.c
+++ b/src/udfs/dnToAbMagSigma.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2011 Serge Monkewitz
+    Copyright (C) 2011-2022 the SciSQL authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/udfs/dnToFlux.c
+++ b/src/udfs/dnToFlux.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2011 Serge Monkewitz
+    Copyright (C) 2011-2022 the SciSQL authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/udfs/dnToFluxSigma.c
+++ b/src/udfs/dnToFluxSigma.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2011 Serge Monkewitz
+    Copyright (C) 2011-2022 the SciSQL authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/udfs/extractInt64.c
+++ b/src/udfs/extractInt64.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2011 Serge Monkewitz
+    Copyright (C) 2011-2022 the SciSQL authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/udfs/fluxToAbMag.c
+++ b/src/udfs/fluxToAbMag.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2011 Serge Monkewitz
+    Copyright (C) 2011-2022 the SciSQL authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/udfs/fluxToAbMagSigma.c
+++ b/src/udfs/fluxToAbMagSigma.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2011 Serge Monkewitz
+    Copyright (C) 2011-2022 the SciSQL authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/udfs/fluxToDn.c
+++ b/src/udfs/fluxToDn.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2011 Serge Monkewitz
+    Copyright (C) 2011-2022 the SciSQL authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/udfs/fluxToDnSigma.c
+++ b/src/udfs/fluxToDnSigma.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2011 Serge Monkewitz
+    Copyright (C) 2011-2022 the SciSQL authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/udfs/getVersion.c
+++ b/src/udfs/getVersion.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2011 Serge Monkewitz
+    Copyright (C) 2011-2022 the SciSQL authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/udfs/nanojanskyToAbMag.c
+++ b/src/udfs/nanojanskyToAbMag.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2011 Serge Monkewitz
+    Copyright (C) 2011-2022 the SciSQL authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/udfs/nanojanskyToAbMagSigma.c
+++ b/src/udfs/nanojanskyToAbMagSigma.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2011 Serge Monkewitz
+    Copyright (C) 2011-2022 the SciSQL authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/udfs/percentile.c
+++ b/src/udfs/percentile.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2011 Serge Monkewitz
+    Copyright (C) 2011-2022 the SciSQL authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/udfs/raiseError.c
+++ b/src/udfs/raiseError.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2011 Serge Monkewitz
+    Copyright (C) 2011-2022 the SciSQL authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/udfs/s2CPolyHtmRanges.c
+++ b/src/udfs/s2CPolyHtmRanges.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2011 Serge Monkewitz
+    Copyright (C) 2011-2022 the SciSQL authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/udfs/s2CPolyToBin.c
+++ b/src/udfs/s2CPolyToBin.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2011 Serge Monkewitz
+    Copyright (C) 2011-2022 the SciSQL authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/udfs/s2CircleHtmRanges.c
+++ b/src/udfs/s2CircleHtmRanges.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2011 Serge Monkewitz
+    Copyright (C) 2011-2022 the SciSQL authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/udfs/s2HtmId.c
+++ b/src/udfs/s2HtmId.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2011 Serge Monkewitz
+    Copyright (C) 2011-2022 the SciSQL authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/udfs/s2HtmLevel.c
+++ b/src/udfs/s2HtmLevel.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2011 Serge Monkewitz
+    Copyright (C) 2011-2022 the SciSQL authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/udfs/s2PtInBox.c
+++ b/src/udfs/s2PtInBox.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2011 Serge Monkewitz
+    Copyright (C) 2011-2022 the SciSQL authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/udfs/s2PtInCPoly.c
+++ b/src/udfs/s2PtInCPoly.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2011 Serge Monkewitz
+    Copyright (C) 2011-2022 the SciSQL authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/udfs/s2PtInCircle.c
+++ b/src/udfs/s2PtInCircle.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2011 Serge Monkewitz
+    Copyright (C) 2011-2022 the SciSQL authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/udfs/s2PtInEllipse.c
+++ b/src/udfs/s2PtInEllipse.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2011 Serge Monkewitz
+    Copyright (C) 2011-2022 the SciSQL authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/util/index.c
+++ b/src/util/index.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2011 Serge Monkewitz
+    Copyright (C) 2011-2022 the SciSQL authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/test/base.py
+++ b/test/base.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 # encoding: utf-8
 #
-# Copyright (C) 2011 Serge Monkewitz
+# Copyright (C) 2011-2022 the SciSQL authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/testAngSep.py
+++ b/test/testAngSep.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 # encoding: utf-8
 #
-# Copyright (C) 2011 Serge Monkewitz
+# Copyright (C) 2011-2022 the SciSQL authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/testHtm.c
+++ b/test/testHtm.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2011 Serge Monkewitz
+    Copyright (C) 2011-2022 the SciSQL authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/test/testMedian.py
+++ b/test/testMedian.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 # encoding: utf-8
 #
-# Copyright (C) 2011 Serge Monkewitz
+# Copyright (C) 2011-2022 the SciSQL authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/testPercentile.py
+++ b/test/testPercentile.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 # encoding: utf-8
 #
-# Copyright (C) 2011 Serge Monkewitz
+# Copyright (C) 2011-2022 the SciSQL authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/testPhotometry.py
+++ b/test/testPhotometry.py
@@ -1,3 +1,26 @@
+#! /usr/bin/env python
+# encoding: utf-8
+#
+# Copyright (C) 2011-2022 the SciSQL authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors:
+#     - Fritz Mueller, SLAC National Accelerator Laboratory
+#
+# Work on this project has been sponsored by LSST and SLAC/DOE.
+#
+
 import math
 import sys
 import unittest

--- a/test/testS2CPoly.py
+++ b/test/testS2CPoly.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 # encoding: utf-8
 #
-# Copyright (C) 2011 Serge Monkewitz
+# Copyright (C) 2011-2022 the SciSQL authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/testS2PtInBox.py
+++ b/test/testS2PtInBox.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 # encoding: utf-8
 #
-# Copyright (C) 2011 Serge Monkewitz
+# Copyright (C) 2011-2022 the SciSQL authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/testS2PtInCircle.py
+++ b/test/testS2PtInCircle.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 # encoding: utf-8
 #
-# Copyright (C) 2011 Serge Monkewitz
+# Copyright (C) 2011-2022 the SciSQL authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/testS2PtInEllipse.py
+++ b/test/testS2PtInEllipse.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 # encoding: utf-8
 #
-# Copyright (C) 2011 Serge Monkewitz
+# Copyright (C) 2011-2022 the SciSQL authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/testSelect.c
+++ b/test/testSelect.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2011 Serge Monkewitz
+    Copyright (C) 2011-2022 the SciSQL authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/tools/docs.py
+++ b/tools/docs.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 # encoding: utf-8
 #
-# Copyright (C) 2011 Serge Monkewitz
+# Copyright (C) 2011-2022 the SciSQL authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/mysql_waf.py
+++ b/tools/mysql_waf.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 # encoding: utf-8
 #
-# Copyright (C) 2011 Serge Monkewitz
+# Copyright (C) 2011-2022 the SciSQL authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/mysqlversion.py
+++ b/tools/mysqlversion.py
@@ -1,3 +1,28 @@
+#! /usr/bin/env python
+# encoding: utf-8
+#
+# Copyright (C) 2011-2022 the SciSQL authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors:
+#     - Fabrice Jammes
+#     - Serge Monkewitz, IPAC/Caltech
+#     - Fritz Mueller, SLAC National Accelerator Laboratory
+#
+# Work on this project has been sponsored by LSST and SLAC/DOE.
+#
+
 from __future__ import print_function
 import argparse
 import operator

--- a/tools/undeploy.py
+++ b/tools/undeploy.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 # encoding: utf-8
 #
-# Copyright (C) 2011 Serge Monkewitz
+# Copyright (C) 2011-2022 the SciSQL authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/wscript
+++ b/wscript
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 # encoding: utf-8
 #
-# Copyright (C) 2011 Serge Monkewitz
+# Copyright (C) 2011-2022 the SciSQL authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
- per previous discussion, copyright holder to "the SciSQL authors"
- year to "2011-2022"
- add header to a few python source files that didn't have it