### PR TITLE
Fix MySQL support and re-enable for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,6 @@ jobs:
           sudo chmod a+w /usr/lib/mysql/plugin
           echo '' | PYTHONPATH=/usr/local/python scisql-deploy.py --mysql-bin=/usr/bin/mariadb --mysql-socket=/run/mysqld/mysqld.sock --mysql-plugin-dir=/usr/lib/mysql/plugin
   MySQL:
-    if: ${{ false }}  # disable for now until portability problems addressed
     runs-on: ubuntu-latest
     steps:
       - name: Set up Python
@@ -43,6 +42,12 @@ jobs:
         uses: ankane/setup-mysql@v1
         with:
           mysql-version: 8.0
+      - name: Adjust MySQL config
+        run: |
+          echo "[mysqld]"                 | sudo tee -a /etc/mysql/conf.d/scisql.cnf
+          echo "secure_file_priv = ''"    | sudo tee -a /etc/mysql/conf.d/scisql.cnf
+          echo "local_infile = 1"         | sudo tee -a /etc/mysql/conf.d/scisql.cnf
+          sudo systemctl restart mysql
       - name: Install add'l packages
         run: |
           pip3 install future mako mysqlclient
@@ -56,7 +61,7 @@ jobs:
       - name: deploy
         run: |
           sudo chmod a+w /usr/lib/mysql/plugin
-          echo '' | PYTHONPATH=/usr/local/python scisql-deploy.py --mysql-bin=/usr/bin/mariadb --mysql-socket=/run/mysqld/mysqld.sock --mysql-plugin-dir=/usr/lib/mysql/plugin
+          echo '' | PYTHONPATH=/usr/local/python scisql-deploy.py --mysql-bin=/usr/bin/mysql --mysql-socket=/run/mysqld/mysqld.sock --mysql-plugin-dir=/usr/lib/mysql/plugin
   Docs:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: deploy
         run: |
           sudo chmod a+w /usr/lib/mysql/plugin
-          echo '' | PYTHONPATH=/usr/local/python scisql-deploy.py --mysql-bin=/usr/bin/mariadb --mysql-socket=/run/mysqld/mysqld.sock --mysql-plugin-dir=/usr/lib/mysql/plugin
+          echo '' | PYTHONPATH=/usr/local/python python -u /usr/local/bin/scisql-deploy.py --mysql-bin=/usr/bin/mariadb --mysql-socket=/run/mysqld/mysqld.sock --mysql-plugin-dir=/usr/lib/mysql/plugin
   MySQL:
     runs-on: ubuntu-latest
     steps:
@@ -61,7 +61,7 @@ jobs:
       - name: deploy
         run: |
           sudo chmod a+w /usr/lib/mysql/plugin
-          echo '' | PYTHONPATH=/usr/local/python scisql-deploy.py --mysql-bin=/usr/bin/mysql --mysql-socket=/run/mysqld/mysqld.sock --mysql-plugin-dir=/usr/lib/mysql/plugin
+          echo '' | PYTHONPATH=/usr/local/python python -u /usr/local/bin/scisql-deploy.py --mysql-bin=/usr/bin/mysql --mysql-socket=/run/mysqld/mysqld.sock --mysql-plugin-dir=/usr/lib/mysql/plugin
   Docs:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ Science Tools for MySQL
 
 sciSQL provides science-specific tools and extensions for SQL. Currently,
 the project contains user defined functions (UDFs) and stored procedures for
-MySQL in the areas of spherical geometry, statistics, and photometry. It is
-distributed under the terms of the Apache License version 2.0.
+MySQL or MariaDB in the areas of spherical geometry, statistics, and photometry.
+It is distributed under the terms of the Apache License version 2.0.
 
 Note that the [docs/index.html](docs/index.html) file in the sciSQL
 distribution contains all the instructions below, as well as documentation
@@ -15,18 +15,18 @@ Installation prerequisites
 
 - [Python 2.5.x or later](http://www.python.org/download/)
 - [Python future 0.16 or later](http://python-future.org/index.html)
-- [MySQL server 5.x](http://dev.mysql.com/downloads/)
-- [MySQLdb 1.2.x](http://sourceforge.net/projects/mysql-python/)
+- [MySQL server 8.x](https://dev.mysql.com/downloads/mysql/) -or- [MariaDB server 10.x](https://mariadb.com/downloads/)
+- [mysqlclient 2.1.x or later](https://github.com/PyMySQL/mysqlclient)
 - [Mako 0.4 or later](http://www.makotemplates.org/download.html)
 
-MySQLdb, a Python DB API 2.0 implementation for MySQL, is required in order
-to run the unit tests and uninstall sciSQL. The Mako templating library is
+`mysqlclient`, a Python DB API 2.0 implementation for MySQL/MariaDB, is required
+in order to run the unit tests and uninstall sciSQL. The Mako templating library is
 required only if you wish to rebuild the HTML documentation. The Python
 future library is required to allow building this software with both Python
 versions 2 and 3.
 
-In order to install the UDFs, you need write permission to the MySQL server
-plug-in directory as well as a MySQL account with admin priviledges.
+In order to install the UDFs, you need write permission to the MySQL/MariaDB server
+plug-in directory as well as a MySQL/MariaDB account with admin priviledges.
 
 Databases reserved for sciSQL use
 ---------------------------------
@@ -46,51 +46,68 @@ database prior to installing sciSQL. If you do not, YOU WILL LOSE DATA.
 Even though the `scisql` and `scisql_test` databases are never automatically
 dropped, their use is STRONGLY DISCOURAGED.
 
-sciSQL configuration
+Build configuration
 --------------------
 
 Run `./configure` from the top-level sciSQL directory. Passing `--help` will
 yield a list of configuration options. Here are the ones most likely to require
-tweaking:
+tweaking if `configure` doesn't work straight out of the box on your system:
 
-| Option            | Description                                                              |
-| ----------------- | ------------------------------------------------------------------------ |
-| `--prefix`        | Set this to the top-level MySQL server install directory                 |
-| `--mysql-user`    | Set this to the name of a MySQL admin user                               |
-| `--mysql-socket`  | Set this to the name of the MySQL server UNIX socket file                |
-| `--scisql-prefix` | Prefix for all UDF and stored procedure names. The default is "sciscl_". |
-
-You will be prompted for the MySQL admin user password during configuration.
-Connection details, including this password, are stored in
-`build/c4che/.my.cnf` in the MySQL options file format. This allows various
-build steps to connect to MySQL without constantly prompting for a password.
-
-Even though the `.my.cnf` file permissions are set such that only its creator
-is allowed read/write access, for security reasons it is still recommended to
-run `make distclean` once sciSQL has been installed. This will remove the
-entire build directory and its contents.
+| Option             | Description                                                              |
+| ------------------ | ------------------------------------------------------------------------ |
+| `--mysql-dir`      | Set this to the top-level MySQL/MariaDB server install tree              |
+| `--mysql-config`   | Point to `mysql_config` or `mariadb_config` configuration tool           |
+| `--mysql-includes` | Point to MySQL/MariaDB headers (`mysql.h` and dependents)                |
+| `--scisql-prefix`  | Prefix for all UDF and stored procedure names. The default is "sciscl_". |
 
 If you wish to build/install only the sciSQL client utilities and documentation,
-run configure with the `--client-only` option. In this case, a MySQL server or
+run configure with the `--client-only` option. In this case, a MySQL/MariaDB server or
 client install is not required, the only executable generated is `scisql_index`
 (a utility which generates HTM indexes for tables of circles or polygons stored
-in tab-separated-value format), and `--prefix` can be set to a directory of your
-choice.
+in tab-separated-value format).
 
-Building and installation
--------------------------
+Building
+--------
 
-sciSQL is built, installed, and uninstalled with the usual make,
-make install, and make uninstall commands.
-
-The install command will CREATE the sciSQL UDFs, stored procedures, and
-databases (including the `scisql_demo` database). It will also automatically
-run the sciSQL unit tests. You can re-run the tests anytime with `make test`.
+sciSQL is built and staged with the usual `make` and `make install` commands.
 
 You may wish to regenerate the HTML documentation if you've chosen a
 non-default value for `--scisql-prefix`, as the HTML distributed with release
 tar-balls is built under the assumption that `--scisql-prefix="scisql_"`.
 To do this, run `make html_docs`.
+
+Deploying sciSQL in a MySQL/MariaDB instance
+--------------------------------------------
+
+Assuming you've installed scisql in `$PREFIX`, update your `PATH` and
+`PYTHONPATH` as described below:
+
+    export PATH="$PREFIX/bin:$PATH"
+    export PYTHONPATH="$PREFIX/python:$PATH"
+
+Check that you have access to a local server instance and run `scisql-deploy.py`. Passing
+`--help` will yield a list of configuration options. Here are the ones most likely to require
+tweaking:
+
+| Option               | Description                                                              |
+| -------------------- | ------------------------------------------------------------------------ |
+| `--mysql-user`       | Set this to the name of a MySQL/MariaDB admin user; defaults to `root`.  |
+| `--mysql-bin`        | Point to the `mysql` or `mariadb` command-line client                    |
+| `--mysql-socket`     | Point to the MySQL/MariaDB server UNIX socket file        |
+| `--mysql-plugin-dir` | Point to server plugin directory, typically `/usr/lib/mysql/plugin`      |
+| `--verbose`          | Verbosity level; possible value are FATAL, ERROR, WARN, INFO, DEBUG      |
+
+You will be prompted for the MySQL/MariaDB admin user password during configuration.
+If you run `scisql-deploy.py` in a script, you can
+use standard input, for example via a pipe, for providing this password.
+Connection details, including this password, are stored in a temporary directory in a file named
+`my-client.cnf` using the MySQL options file format. This temporary file is removed at the end
+of the process, unless you set the verbosity level to DEBUG.
+
+The `scisql-deploy.py` command will CREATE the sciSQL UDFs, stored procedures, and
+databases (including the scisql_demo database). It will also automatically
+run the sciSQL integration tests, which check that sciSQL is correctly deployed.
+You can re-run the tests anytime by invoking `scisql-deploy.py` with the `--test` option.
 
 Finally, note that after installation each UDF will be available under two
 names: one including a version number and one without. For example, assuming
@@ -100,16 +117,17 @@ a hypothetical UDF named "bar" would be available as:
     foo_bar
     foo_bar_1_2_3
 
-The uninstall command will drop the versioned sciSQL UDFs and stored
+Invoking `scisql-deploy.py` with the `--undeploy` option
+will drop the versioned sciSQL UDFs and stored
 procedures. It will also drop the unversioned UDFs/procedures, but only
 if the unversioned UDF/procedure was created by the version of
 sciSQL being uninstalled. As a consequence, it is possible to have
 multiple versions of sciSQL installed at the same time, and the behavior
-of two versions can be compared from within a single MySQL instance.
+of two versions can be compared from within a single MySQL/MariaDB instance.
 An unversioned name will resolve to the most recently installed versioned
 name.
 
-The uninstall command will also drop the `scisql_demo` database.
+An undeploy will also drop the scisql_demo database.
 
 Rebuilding sciSQL
 -----------------
@@ -118,30 +136,31 @@ If you've already installed sciSQL, say using a UDF/procedure name
 prefix of "foo_", and then decide you'd like to change the prefix to "bar_",
 do the following from the top-level sciSQL directory:
 
-    % make uninstall                        # Uninstalls the UDFs and stored procedures named foo_*
+    % scisql-deploy.py ... --undeploy       # Uninstalls the UDFs and stored procedures named foo_*
     % make distclean                        # Removes all build products and configuration files
     % configure --scisql-prefix=bar_ ...    # Reconfigures sciSQL (sets new name prefix)
     % make                                  # Rebuilds sciSQL
-    % make install                          # Reinstalls sciSQL
+    % make install                          # Restages sciSQL
+    % scisql-deploy.py ...                  # Redeploys sciSQL
 
-No MySQL restart is required. Note that multiple installations of the same
+No MySQL/MariaDB restart is required. Note that multiple installations of the same
 version of sciSQL with different UDF/procedure name prefixes can coexist on
-a single MySQL instance.
+a single MySQL/MariaDB instance.
 
-MySQL server restarts
----------------------
+MySQL/MariaDB server restarts
+-----------------------------
 
 Installing different versions of sciSQL, or multiple copies of the same
-version with different UDF/procedure name prefixes, does not require a MySQL
+version with different UDF/procedure name prefixes, does not require a
 server restart.
 
 Only sciSQL developers should need to perform restarts. They are
 required when changing the name of a UDF without changing the name of the
-shared library installed into the MySQL plugin directory. In this case,
+shared library installed into the server plugin directory. In this case,
 an attempt to install the updated shared library will sometimes result in
-MySQL reporting that it cannot find symbol names that are actually
-present. This is presumably due to MySQL server and/or OS level caching
-effects, and restarting MySQL resolves the problem.
+MySQL/MariaDB reporting that it cannot find symbol names that are actually
+present. This is presumably due to server and/or OS level caching
+effects, and restarting the server resolves the problem.
 
 Reporting bugs and getting help
 -------------------------------

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,0 +1,19 @@
+### 0.3.11 (upcoming)
+
+* Adds `nanojanskyToAbMag`, `nanojanksyToAbMagSigma`, `abMagToNanojansky` and `abMagToNanojanskySigma`
+  photometry UDFs.
+
+* Adds MySQL 8.0 compatibility (recent releases had only been tested against MariaDB 10.x).  Added MariaDB,
+  MySQL, and documentation CI builds via github actions.
+
+* Documentation now published in github pages ([https://smonkewitz.github.io/scisql](https://smonkewitz.github.io/scisql))
+
+### 0.3.10
+
+* Update use of deprecated method `xml.etree.ElementTree.Element.getiterator` in the docs.py Python
+  documentation generation script.
+
+### 0.3.9
+
+* Upgrade waf to 2.0.15, which supports using Python 3.7 for builds.
+

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,0 @@
-TODO
-====
-
-- some UDFs and stored procedures still need unit tests
-- Consider creating temp file for median() and select() in the MySQL TMP_DIR
-  instead of /tmp

--- a/docs/index.html
+++ b/docs/index.html
@@ -30,7 +30,7 @@
 	</li>
 	<li>
 		
-	<h3><a href="#install">Build, Installation &amp; Deployment</a></h3>
+	<h3><a href="#install">Build, Installation, and Deployment</a></h3>
 
 		
 
@@ -130,11 +130,10 @@
 	
         <div class="section-docs">
         <p>
-        sciSQL provides science-specific tools and extensions for SQL. Currently, the project
-        contains user defined functions (UDFs) and stored procedures for MySQL in the areas
-        of spherical geometry, statistics, and photometry. The project was motivated by the
-        needs of the <a href="http://www.lsst.org/">Large Synoptic Survey Telescope</a> (LSST)
-        and has been sponsored by LSST and <a href="http://slac.stanford.edu/">SLAC</a> /
+        sciSQL provides science-specific tools and extensions for SQL. Currently, the project contains user
+        defined functions (UDFs) and stored procedures for MySQL or MariaDB in the areas of spherical
+        geometry, statistics, and photometry. The project was motivated by the needs of the <a href="http://www.lsst.org/">Rubin Observatory Legacy Survey of Space and Time</a> (LSST) and has been
+        sponsored by LSST and <a href="http://slac.stanford.edu/">SLAC</a> /
         <a href="http://www.energy.gov/">DOE</a>. sciSQL is distributed under the terms of the
         <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License version 2.0</a>.
         </p>
@@ -173,10 +172,11 @@
         <dl>
                 <dt><a href="http://www.python.org/download/">Python 2.5.x or later</a></dt>
                 <dt><a href="http://python-future.org/index.html">Python future 0.16 or later</a></dt>
-                <dt><a href="http://dev.mysql.com/downloads/">MySQL server 5.x</a></dt>
-                <dt><a href="http://sourceforge.net/projects/mysql-python/">MySQLdb 1.2.x</a></dt>
+                <dt><a href="https://dev.mysql.com/downloads/mysql/">MySQL server 8.x</a> -or-
+                  <a href="https://mariadb.com/downloads/">MariaDB server 10.x</a></dt>
+                <dt><a href="https://github.com/PyMySQL/mysqlclient">mysqlclient 2.1.x or later</a></dt>
                 <dd>
-                        This is a Python DB API 2.0 implementation for MySQL, and is
+                        This is a Python DB API 2.0 implementation for MySQL/MariaDB, and is
                         required when running the unit tests and uninstalling sciSQL.
                 </dd>
                 <dt><a href="http://www.makotemplates.org/download.html">Mako 0.4 or later</a></dt>
@@ -186,8 +186,8 @@
                 </dd>
         </dl>
         <p>
-        In order to install the UDFs, you will need write permission to the MySQL server
-        plug-in directory, as well as a MySQL account with admin priviledges.
+        In order to install the UDFs, you will need write permission to the MySQL/MariaDB server
+        plug-in directory, as well as a MySQL/MariaDB account with admin priviledges.
         </p>
 
         <h3 class="warning">Databases reserved for sciSQL use</h3>
@@ -217,13 +217,15 @@
         <p>
         Run <tt>./configure</tt> from the top-level sciSQL directory. Passing <tt>--help</tt>
         will yield a list of configuration options. Here are the ones most likely to require
-        tweaking:
+        tweaking if <tt>./configure</tt> doesn't work straight out of the box on your system:
         </p>
         <dl>
-                <dt><tt>--prefix</tt></dt>
-                <dd>Set this to the top-level directory which will contains sciSQL tools and shared library</dd>
+                <dt><tt>--mysql-dir</tt></dt>
+                <dd>Set this to the top-level of the MySQL/MariaDB server install tree</dd>
+                <dt><tt>--mysql-config</tt></dt>
+                <dd>Point to <tt>mysql_config</tt> or <tt>mariadb_config</tt> configuration tool</dd>
                 <dt><tt>--mysql-includes</tt></dt>
-                <dd>Set this to the top-level directory where the MySQL header files are located</dd>
+                <dd>Point to MySQL/MariaDB headers (<tt>mysql.h</tt> and dependents)</dd>
                 <dt><tt>--scisql-prefix</tt></dt>
                 <dd>
                 This string will be used as a prefix for all sciSQL UDF and stored procedure
@@ -233,26 +235,16 @@
         </dl>
         <p>
         If you wish to build/install only the sciSQL client utilities and documentation,
-        run configure with the --client-only option. In this case, a MySQL server or
+        run configure with the <tt>--client-only</tt> option. In this case, a MySQL/MariaDB server or
         client install is not required, the only executable generated is scisql_index
         (a utility which generates HTM indexes for tables of circles or polygons stored
         in tab-separated-value format).
         </p>
 
-        <h3>Build/Install</h3>
+        <h3>Build</h3>
         <p>
-        sciSQL is built, installed, and uninstalled with the usual <tt>make</tt>,
-        <tt>make install</tt>, and <tt>make uninstall</tt> commands.
-        </p>
-        <p>
-        The <tt>build</tt> command also automatically run the sciSQL unit tests.
-        You can re-run the tests anytime with <tt>make test</tt>.
-        </p>
-        <p>
-        The <tt>install</tt> command will he sciSQL UDFs, stored procedures, and
-        databases (including the scisql_demo database). It will also automatically
-        run the sciSQL unit tests.
-        You can re-run the tests anytime with <tt>make test</tt>.
+        sciSQL is built and staged with the usual <tt>make</tt> and <tt>make install</tt>
+        commands.
         </p>
         <p>
         You may wish to regenerate the HTML documentation if you've chosen a
@@ -261,36 +253,40 @@
         To do this, run <tt>make html_docs</tt>.
         </p>
 
-        <h3>Deploying sciSQL in a MySQL instance</h3>
-        <p> Assuming you've installed scisql in $PREFIX, update your PATH and PYTHONPATH as described below:
+        <h3>Deploying sciSQL in a MySQL/MariaDB instance</h3>
+        <p> Assuming you've installed scisql in <tt>$PREFIX</tt>, update your <tt>PATH</tt> and
+        <tt>PYTHONPATH</tt> as described below:
         <pre class="prettyprint lang-bash linenums">
 export PATH="$PREFIX/bin:$PATH"
 export PYTHONPATH="$PREFIX/python:$PATH"</pre>
-        Check that your have access to a local MySQL server instance and run <tt>scisql-deploy.py</tt>. Passing <tt>--help</tt>
-        will yield a list of configuration options. Here are the ones most likely to require
+        Check that you have access to a local server instance and run <tt>scisql-deploy.py</tt>. Passing
+        <tt>--help</tt> will yield a list of configuration options. Here are the ones most likely to require
         tweaking:
         </p>
         <dl>
                 <dt><tt>--mysql-user</tt></dt>
-                <dd>Set this to the name of a MySQL admin user. Default to 'root'</dd>
+                <dd>Set this to the name of a MySQL/MariaDB admin user; defaults to <tt>root</tt></dd>
+                <dt><tt>--mysql-bin</tt></dt>
+                <dd>Point to the <tt>mysql</tt> or <tt>mariadb</tt> command-line client</dd>
                 <dt><tt>--mysql-socket</tt></dt>
-                <dd>Set this to the name of the MySQL server UNIX socket file</dd>
+                <dd>Point to the MySQL/MariaDB server UNIX socket file</dd>
                 <dt><tt>--verbose</tt></dt>
-                <dd>Verbose level, possible value are FATAL, ERROR, WARN, INFO, DEBUG</dd>
+                <dd>Verbosity level; possible value are FATAL, ERROR, WARN, INFO, DEBUG</dd>
         </dl>
         <p>
-        You will be prompted for the MySQL admin user password during configuration.
+        You will be prompted for the MySQL/MariaDB admin user password during configuration.
         If you run <tt>scisql-deploy.py</tt> in a script, you can
         use standard input, for example via a pipe, for providing this password.
         Connection details, including this password, are stored in a temporary directory in a file named
         <tt>my-client.cnf</tt> using the MySQL options file format. This temporary file is removed at the end
-        of the process, unless you set the verbose level to DEBUG
+        of the process, unless you set the verbose level to DEBUG.
         </p>
         <p>
         The <tt>scisql-deploy.py</tt> command will CREATE the sciSQL UDFs, stored procedures, and
         databases (including the scisql_demo database). It will also automatically
-        run the sciSQL integration tests, which check that sciSQL is correctly deployed in MySQL.
-        You can re-run the tests anytime using <tt>--test</tt> option.
+        run the sciSQL integration tests, which check that sciSQL is correctly deployed.
+        You can re-run the tests anytime by invoking <tt>scisql-deploy.py</tt> with the 
+        <tt>--test</tt> option.
         </p>
         <p>
         Finally, note that after installation each UDF will be available under two
@@ -300,17 +296,18 @@ export PYTHONPATH="$PREFIX/python:$PATH"</pre>
         </p>
         <ul><li>foo_bar</li><li>foo_bar_1_2_3</li></ul>
         <p>
-        The <tt>uninstall</tt> command will drop the versioned sciSQL UDFs and stored
+        Invoking <tt>scisql-deploy.py</tt> with the <tt>--undeploy</tt> option
+        will drop the versioned sciSQL UDFs and stored
         procedures. It will also drop the unversioned UDFs/procedures, but only
         if the unversioned UDF/procedure was created by the version of
         sciSQL being uninstalled. As a consequence, it is possible to have
         multiple versions of sciSQL installed at the same time, and the behavior
-        of two versions can be compared from within a single MySQL instance.
+        of two versions can be compared from within a single MySQL/MariaDB instance.
         An unversioned name will resolve to the most recently installed versioned
         name.
         </p>
         <p>
-        The uninstall command will also drop the scisql_demo database.
+        An updeploy will also drop the scisql_demo database.
         </p>
 
         <h3>Rebuilding sciSQL</h3>
@@ -320,47 +317,41 @@ export PYTHONPATH="$PREFIX/python:$PATH"</pre>
         do the following from the top-level sciSQL directory:
         </p>
         <dl>
-        <dt><tt>scisql-deploy.py --mysql-socket=/path/to/mysql/sock --undeploy</tt></dt><dd>Uninstalls the UDFs and stored procedures named <tt>foo_*</tt>.</dd>
-        <dt><tt>make uninstall</tt></dt><dd>Empty sciSQL install directory (i.e. $PREFIX)</dd>
+        <dt><tt>scisql-deploy.py ... --undeploy</tt></dt><dd>Uninstalls the UDFs and stored procedures named <tt>foo_*</tt>.</dd>
         <dt><tt>make distclean</tt></dt><dd>Removes all build products and configuration files.</dd>
         <dt><tt>configure --scisql-prefix=bar_ ...</tt></dt><dd>Reconfigures sciSQL (sets new name prefix).</dd>
         <dt><tt>make</tt></dt><dd>Rebuilds sciSQL.</dd>
-        <dt><tt>make install</tt></dt><dd>Reinstalls sciSQL.</dd>
-        <dt><tt>scisql-deploy.py --mysql-socket=/path/to/mysql/sock</tt></dt><dd>Deploy sciSQL in your MySQL instance.</dd>
+        <dt><tt>make install</tt></dt><dd>Restages sciSQL.</dd>
+        <dt><tt>scisql-deploy.py ...</tt></dt><dd>Redeploys sciSQL</dd>
         </dl>
         <p>
-        No MySQL restart is required. Note that multiple installations of the same
+        No MySQL/MariaDB restart is required. Note that multiple installations of the same
         version of sciSQL with different UDF/procedure name prefixes can coexist on
-        a single MySQL instance.
+        a single MySQL/MariaDB instance.
         </p>
 
-
-        <h3>MySQL server restarts</h3>
+        <h3>MySQL/MariaDB server restarts</h3>
         <p>
         Installing different versions of sciSQL, or multiple copies of the same
-        version with different UDF/procedure name prefixes, does not require a MySQL
+        version with different UDF/procedure name prefixes, does not require a
         server restart.
         </p>
         <p>
         Only sciSQL developers should need to perform restarts. They are
         required when changing the name of a UDF without changing the name of the
-        shared library installed into the MySQL plugin directory. In this case,
+        shared library installed into the server plugin directory. In this case,
         an attempt to install the updated shared library will sometimes result in
-        MySQL reporting that it cannot find symbol names that are actually
-        present. This is presumably due to MySQL server and/or OS level caching
-        effects, and restarting MySQL resolves the problem.
+        MySQL/MariaDB reporting that it cannot find symbol names that are actually
+        present. This is presumably due to server and/or OS level caching
+        effects, and restarting the server resolves the problem.
         </p>
 
         <h3>Reporting bugs and getting help</h3>
         <p>
         If you encounter test-case failures, or think you've identified a
-        bug in the sciSQL code, please file a report here:
+        bug in the sciSQL code, or would just like to ask a question, please
+        <a href="https://github.com/smonkewitz/scisql/issues">submit an issue</a>.
         </p>
-        <p><a href="https://bugs.launchpad.net/scisql/+filebug">https://bugs.launchpad.net/scisql/+filebug</a></p>
-        <p>
-        For other help or inquiries, submit your questions here:
-        </p>
-        <p><a href="https://answers.launchpad.net/scisql/+addquestion">https://answers.launchpad.net/scisql/+addquestion</a></p>
         </div>
 
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -556,6 +556,7 @@ SELECT scienceCcdExposureId,
                 Then, run the sciSQL region indexing utility:
         </p>
         <pre class="prettyprint lang-bash linenums">
+sudo chmod a+r /tmp/scisql_demo_ccds.tsv
 scisql_index -l 10 /tmp/scisql_demo_htmid10.tsv /tmp/scisql_demo_ccds.tsv</pre>
         <p>
                 and load the results:

--- a/src/udf.h
+++ b/src/udf.h
@@ -59,11 +59,18 @@
 #define SCISQL_UDF_NAME(name) \
     SCISQL_STRINGIZE(SCISQL_VERSIONED_FNAME(name, SCISQL_NO_SUFFIX))
 
+/*  Macros to address API type differences between MySQL 8 and MariaDB 10.
+ */
+#ifdef LIBMARIADB
+#define SCISQL_BOOL my_bool
+#else
+#define SCISQL_BOOL bool
+#endif
 
 /*  Implements an unversioned init function in terms of the versioned one.
  */
 #define SCISQL_UDF_INIT(name) \
-    SCISQL_API my_bool SCISQL_FNAME(name, _init) ( \
+    SCISQL_API SCISQL_BOOL SCISQL_FNAME(name, _init) ( \
         UDF_INIT *initid, \
         UDF_ARGS *args, \
         char *message) \

--- a/src/udfs/abMagToDn.c
+++ b/src/udfs/abMagToDn.c
@@ -64,7 +64,7 @@ extern "C" {
 #endif
 
 
-SCISQL_API my_bool SCISQL_VERSIONED_FNAME(abMagToDn, _init) (
+SCISQL_API SCISQL_BOOL SCISQL_VERSIONED_FNAME(abMagToDn, _init) (
     UDF_INIT *initid,
     UDF_ARGS *args,
     char *message)

--- a/src/udfs/abMagToDnSigma.c
+++ b/src/udfs/abMagToDnSigma.c
@@ -74,13 +74,13 @@ extern "C" {
 #endif
 
 
-SCISQL_API my_bool SCISQL_VERSIONED_FNAME(abMagToDnSigma, _init) (
+SCISQL_API SCISQL_BOOL SCISQL_VERSIONED_FNAME(abMagToDnSigma, _init) (
     UDF_INIT *initid,
     UDF_ARGS *args,
     char *message)
 {
     size_t i;
-    my_bool const_item = 1;
+    SCISQL_BOOL const_item = 1;
     if (args->arg_count != 4) {
         snprintf(message, MYSQL_ERRMSG_SIZE, SCISQL_UDF_NAME(abMagToDnSigma)
                  " expects exactly 4 arguments");

--- a/src/udfs/abMagToFlux.c
+++ b/src/udfs/abMagToFlux.c
@@ -59,7 +59,7 @@ extern "C" {
 #endif
 
 
-SCISQL_API my_bool SCISQL_VERSIONED_FNAME(abMagToFlux, _init) (
+SCISQL_API SCISQL_BOOL SCISQL_VERSIONED_FNAME(abMagToFlux, _init) (
     UDF_INIT *initid,
     UDF_ARGS *args,
     char *message)

--- a/src/udfs/abMagToFluxSigma.c
+++ b/src/udfs/abMagToFluxSigma.c
@@ -65,7 +65,7 @@ extern "C" {
 #endif
 
 
-SCISQL_API my_bool SCISQL_VERSIONED_FNAME(abMagToFluxSigma, _init) (
+SCISQL_API SCISQL_BOOL SCISQL_VERSIONED_FNAME(abMagToFluxSigma, _init) (
     UDF_INIT *initid,
     UDF_ARGS *args,
     char *message)

--- a/src/udfs/abMagToNanojansky.c
+++ b/src/udfs/abMagToNanojansky.c
@@ -59,7 +59,7 @@ extern "C" {
 #endif
 
 
-SCISQL_API my_bool SCISQL_VERSIONED_FNAME(abMagToNanojansky, _init) (
+SCISQL_API SCISQL_BOOL SCISQL_VERSIONED_FNAME(abMagToNanojansky, _init) (
     UDF_INIT *initid,
     UDF_ARGS *args,
     char *message)

--- a/src/udfs/abMagToNanojanskySigma.c
+++ b/src/udfs/abMagToNanojanskySigma.c
@@ -65,7 +65,7 @@ extern "C" {
 #endif
 
 
-SCISQL_API my_bool SCISQL_VERSIONED_FNAME(abMagToNanojanskySigma, _init) (
+SCISQL_API SCISQL_BOOL SCISQL_VERSIONED_FNAME(abMagToNanojanskySigma, _init) (
     UDF_INIT *initid,
     UDF_ARGS *args,
     char *message)

--- a/src/udfs/angSep.c
+++ b/src/udfs/angSep.c
@@ -100,13 +100,13 @@ extern "C" {
 #endif
 
 
-SCISQL_API my_bool SCISQL_VERSIONED_FNAME(angSep, _init) (
+SCISQL_API SCISQL_BOOL SCISQL_VERSIONED_FNAME(angSep, _init) (
     UDF_INIT *initid,
     UDF_ARGS *args,
     char *message
 ) {
     size_t i;
-    my_bool maybe_null = 0, const_item = 1;
+    SCISQL_BOOL maybe_null = 0, const_item = 1;
     if (args->arg_count != 4 && args->arg_count != 6) {
         snprintf(message, MYSQL_ERRMSG_SIZE,
                  SCISQL_UDF_NAME(angSep) " expects 4 or 6 arguments");

--- a/src/udfs/dnToAbMag.c
+++ b/src/udfs/dnToAbMag.c
@@ -67,7 +67,7 @@ extern "C" {
 #endif
 
 
-SCISQL_API my_bool SCISQL_VERSIONED_FNAME(dnToAbMag, _init) (
+SCISQL_API SCISQL_BOOL SCISQL_VERSIONED_FNAME(dnToAbMag, _init) (
     UDF_INIT *initid,
     UDF_ARGS *args,
     char *message)

--- a/src/udfs/dnToAbMagSigma.c
+++ b/src/udfs/dnToAbMagSigma.c
@@ -77,13 +77,13 @@ extern "C" {
 #endif
 
 
-SCISQL_API my_bool SCISQL_VERSIONED_FNAME(dnToAbMagSigma, _init) (
+SCISQL_API SCISQL_BOOL SCISQL_VERSIONED_FNAME(dnToAbMagSigma, _init) (
     UDF_INIT *initid,
     UDF_ARGS *args,
     char *message)
 {
     size_t i;
-    my_bool const_item = 1;
+    SCISQL_BOOL const_item = 1;
     if (args->arg_count != 4) {
         snprintf(message, MYSQL_ERRMSG_SIZE, SCISQL_UDF_NAME(dnToAbMagSigma)
                  " expects exactly 4 arguments");

--- a/src/udfs/dnToFlux.c
+++ b/src/udfs/dnToFlux.c
@@ -69,7 +69,7 @@ extern "C" {
 #endif
 
 
-SCISQL_API my_bool SCISQL_VERSIONED_FNAME(dnToFlux, _init) (
+SCISQL_API SCISQL_BOOL SCISQL_VERSIONED_FNAME(dnToFlux, _init) (
     UDF_INIT *initid,
     UDF_ARGS *args,
     char *message)

--- a/src/udfs/dnToFluxSigma.c
+++ b/src/udfs/dnToFluxSigma.c
@@ -78,13 +78,13 @@ extern "C" {
 #endif
 
 
-SCISQL_API my_bool SCISQL_VERSIONED_FNAME(dnToFluxSigma, _init) (
+SCISQL_API SCISQL_BOOL SCISQL_VERSIONED_FNAME(dnToFluxSigma, _init) (
     UDF_INIT *initid,
     UDF_ARGS *args,
     char *message)
 {
     size_t i;
-    my_bool const_item = 1;
+    SCISQL_BOOL const_item = 1;
     if (args->arg_count != 4) {
         snprintf(message, MYSQL_ERRMSG_SIZE, SCISQL_UDF_NAME(dnToFluxSigma)
                  " expects exactly 2 arguments");

--- a/src/udfs/extractInt64.c
+++ b/src/udfs/extractInt64.c
@@ -66,7 +66,7 @@ typedef union {
 } _scisql_int64_bytes;
 
 
-SCISQL_API my_bool SCISQL_VERSIONED_FNAME(extractInt64, _init) (
+SCISQL_API SCISQL_BOOL SCISQL_VERSIONED_FNAME(extractInt64, _init) (
     UDF_INIT *initid,
     UDF_ARGS *args,
     char *message)

--- a/src/udfs/fluxToAbMag.c
+++ b/src/udfs/fluxToAbMag.c
@@ -63,7 +63,7 @@ extern "C" {
 #endif
 
 
-SCISQL_API my_bool SCISQL_VERSIONED_FNAME(fluxToAbMag, _init) (
+SCISQL_API SCISQL_BOOL SCISQL_VERSIONED_FNAME(fluxToAbMag, _init) (
     UDF_INIT *initid,
     UDF_ARGS *args,
     char *message)

--- a/src/udfs/fluxToAbMagSigma.c
+++ b/src/udfs/fluxToAbMagSigma.c
@@ -72,7 +72,7 @@ extern "C" {
 #endif
 
 
-SCISQL_API my_bool SCISQL_VERSIONED_FNAME(fluxToAbMagSigma, _init) (
+SCISQL_API SCISQL_BOOL SCISQL_VERSIONED_FNAME(fluxToAbMagSigma, _init) (
     UDF_INIT *initid,
     UDF_ARGS *args,
     char *message)

--- a/src/udfs/fluxToDn.c
+++ b/src/udfs/fluxToDn.c
@@ -68,7 +68,7 @@ extern "C" {
 #endif
 
 
-SCISQL_API my_bool SCISQL_VERSIONED_FNAME(fluxToDn, _init) (
+SCISQL_API SCISQL_BOOL SCISQL_VERSIONED_FNAME(fluxToDn, _init) (
     UDF_INIT *initid,
     UDF_ARGS *args,
     char *message)

--- a/src/udfs/fluxToDnSigma.c
+++ b/src/udfs/fluxToDnSigma.c
@@ -79,13 +79,13 @@ extern "C" {
 #endif
 
 
-SCISQL_API my_bool SCISQL_VERSIONED_FNAME(fluxToDnSigma, _init) (
+SCISQL_API SCISQL_BOOL SCISQL_VERSIONED_FNAME(fluxToDnSigma, _init) (
     UDF_INIT *initid,
     UDF_ARGS *args,
     char *message)
 {
     size_t i;
-    my_bool const_item = 1;
+    SCISQL_BOOL const_item = 1;
     if (args->arg_count != 4) {
         snprintf(message, MYSQL_ERRMSG_SIZE, SCISQL_UDF_NAME(fluxToDnSigma)
                  " expects exactly 4 arguments");

--- a/src/udfs/getVersion.c
+++ b/src/udfs/getVersion.c
@@ -44,7 +44,7 @@ extern "C" {
 #endif
 
 
-SCISQL_API my_bool SCISQL_FNAME(getVersion, _init) (
+SCISQL_API SCISQL_BOOL SCISQL_FNAME(getVersion, _init) (
     UDF_INIT *initid,
     UDF_ARGS *args,
     char *message)

--- a/src/udfs/median.c
+++ b/src/udfs/median.c
@@ -86,7 +86,7 @@ extern "C" {
 #endif
 
 
-SCISQL_API my_bool SCISQL_VERSIONED_FNAME(median, _init) (
+SCISQL_API SCISQL_BOOL SCISQL_VERSIONED_FNAME(median, _init) (
     UDF_INIT *initid,
     UDF_ARGS *args,
     char *message)

--- a/src/udfs/nanojanskyToAbMag.c
+++ b/src/udfs/nanojanskyToAbMag.c
@@ -63,7 +63,7 @@ extern "C" {
 #endif
 
 
-SCISQL_API my_bool SCISQL_VERSIONED_FNAME(nanojanskyToAbMag, _init) (
+SCISQL_API SCISQL_BOOL SCISQL_VERSIONED_FNAME(nanojanskyToAbMag, _init) (
     UDF_INIT *initid,
     UDF_ARGS *args,
     char *message)

--- a/src/udfs/nanojanskyToAbMagSigma.c
+++ b/src/udfs/nanojanskyToAbMagSigma.c
@@ -72,7 +72,7 @@ extern "C" {
 #endif
 
 
-SCISQL_API my_bool SCISQL_VERSIONED_FNAME(nanojanskyToAbMagSigma, _init) (
+SCISQL_API SCISQL_BOOL SCISQL_VERSIONED_FNAME(nanojanskyToAbMagSigma, _init) (
     UDF_INIT *initid,
     UDF_ARGS *args,
     char *message)

--- a/src/udfs/percentile.c
+++ b/src/udfs/percentile.c
@@ -108,7 +108,7 @@ extern "C" {
 #endif
 
 
-SCISQL_API my_bool SCISQL_VERSIONED_FNAME(percentile, _init) (
+SCISQL_API SCISQL_BOOL SCISQL_VERSIONED_FNAME(percentile, _init) (
     UDF_INIT* initid,
     UDF_ARGS* args,
     char* message)

--- a/src/udfs/raiseError.c
+++ b/src/udfs/raiseError.c
@@ -54,7 +54,7 @@ extern "C" {
 #endif
 
 
-SCISQL_API my_bool SCISQL_VERSIONED_FNAME(raiseError, _init) (
+SCISQL_API SCISQL_BOOL SCISQL_VERSIONED_FNAME(raiseError, _init) (
     UDF_INIT *initid SCISQL_UNUSED,
     UDF_ARGS *args,
     char *message)

--- a/src/udfs/s2CPolyHtmRanges.c
+++ b/src/udfs/s2CPolyHtmRanges.c
@@ -80,13 +80,13 @@ extern "C" {
 #endif
 
 
-SCISQL_API my_bool SCISQL_VERSIONED_FNAME(s2CPolyHtmRanges, _init) (
+SCISQL_API SCISQL_BOOL SCISQL_VERSIONED_FNAME(s2CPolyHtmRanges, _init) (
     UDF_INIT *initid,
     UDF_ARGS *args,
     char *message)
 {
     size_t i;
-    my_bool const_item = 1;
+    SCISQL_BOOL const_item = 1;
     if (args->arg_count != 3) {
         snprintf(message, MYSQL_ERRMSG_SIZE, SCISQL_UDF_NAME(s2CPolyHtmRanges)
                  " expects exactly 3 arguments");

--- a/src/udfs/s2CPolyToBin.c
+++ b/src/udfs/s2CPolyToBin.c
@@ -101,13 +101,13 @@ extern "C" {
 #endif
 
 
-SCISQL_API my_bool SCISQL_VERSIONED_FNAME(s2CPolyToBin, _init) (
+SCISQL_API SCISQL_BOOL SCISQL_VERSIONED_FNAME(s2CPolyToBin, _init) (
     UDF_INIT *initid,
     UDF_ARGS *args,
     char *message)
 {
     size_t i;
-    my_bool const_item = 1;
+    SCISQL_BOOL const_item = 1;
     if (args->arg_count < 6 ||
         args->arg_count > 2 * SCISQL_MAX_VERTS ||
         (args->arg_count & 1) != 0) {

--- a/src/udfs/s2CircleHtmRanges.c
+++ b/src/udfs/s2CircleHtmRanges.c
@@ -100,13 +100,13 @@ extern "C" {
 #endif
 
 
-SCISQL_API my_bool SCISQL_VERSIONED_FNAME(s2CircleHtmRanges, _init) (
+SCISQL_API SCISQL_BOOL SCISQL_VERSIONED_FNAME(s2CircleHtmRanges, _init) (
     UDF_INIT *initid,
     UDF_ARGS *args,
     char *message)
 {
     size_t i;
-    my_bool const_item = 1;
+    SCISQL_BOOL const_item = 1;
     if (args->arg_count != 5) {
         snprintf(message, MYSQL_ERRMSG_SIZE, SCISQL_UDF_NAME(s2CircleHtmRanges)
                  " expects exactly 5 arguments");

--- a/src/udfs/s2HtmId.c
+++ b/src/udfs/s2HtmId.c
@@ -81,13 +81,13 @@ extern "C" {
 #endif
 
 
-SCISQL_API my_bool SCISQL_VERSIONED_FNAME(s2HtmId, _init) (
+SCISQL_API SCISQL_BOOL SCISQL_VERSIONED_FNAME(s2HtmId, _init) (
     UDF_INIT *initid,
     UDF_ARGS *args,
     char *message)
 {
     size_t i;
-    my_bool const_item = 1;
+    SCISQL_BOOL const_item = 1;
     if (args->arg_count != 3) {
         snprintf(message, MYSQL_ERRMSG_SIZE,
                  SCISQL_UDF_NAME(s2HtmId) " expects exactly 3 arguments");

--- a/src/udfs/s2HtmLevel.c
+++ b/src/udfs/s2HtmLevel.c
@@ -53,7 +53,7 @@ extern "C" {
 #endif
 
 
-SCISQL_API my_bool SCISQL_VERSIONED_FNAME(s2HtmLevel, _init) (
+SCISQL_API SCISQL_BOOL SCISQL_VERSIONED_FNAME(s2HtmLevel, _init) (
     UDF_INIT *initid,
     UDF_ARGS *args,
     char *message)

--- a/src/udfs/s2PtInBox.c
+++ b/src/udfs/s2PtInBox.c
@@ -105,13 +105,13 @@ extern "C" {
 #endif
 
 
-SCISQL_API my_bool SCISQL_VERSIONED_FNAME(s2PtInBox, _init) (
+SCISQL_API SCISQL_BOOL SCISQL_VERSIONED_FNAME(s2PtInBox, _init) (
     UDF_INIT *initid,
     UDF_ARGS *args,
     char *message)
 {
     int i;
-    my_bool const_item = 1;
+    SCISQL_BOOL const_item = 1;
     if (args->arg_count != 6) {
         snprintf(message, MYSQL_ERRMSG_SIZE, SCISQL_UDF_NAME(s2PtInBox)
                  " expects exactly 6 arguments");

--- a/src/udfs/s2PtInCPoly.c
+++ b/src/udfs/s2PtInCPoly.c
@@ -121,13 +121,13 @@ typedef struct {
 } _scisql_ptpoly_state;
 
 
-SCISQL_API my_bool SCISQL_VERSIONED_FNAME(s2PtInCPoly, _init) (
+SCISQL_API SCISQL_BOOL SCISQL_VERSIONED_FNAME(s2PtInCPoly, _init) (
     UDF_INIT *initid,
     UDF_ARGS *args,
     char *message)
 {
     size_t i;
-    my_bool const_item = 1, const_pos = 1, const_poly = 1;
+    SCISQL_BOOL const_item = 1, const_pos = 1, const_poly = 1;
 
     if (args->arg_count != 3) {
         if (args->arg_count < 8 ||

--- a/src/udfs/s2PtInCircle.c
+++ b/src/udfs/s2PtInCircle.c
@@ -93,13 +93,13 @@ typedef struct {
 } _scisql_dist2_cache;
 
 
-SCISQL_API my_bool SCISQL_VERSIONED_FNAME(s2PtInCircle, _init) (
+SCISQL_API SCISQL_BOOL SCISQL_VERSIONED_FNAME(s2PtInCircle, _init) (
     UDF_INIT *initid,
     UDF_ARGS *args,
     char *message)
 {
     size_t i;
-    my_bool const_item = 1;
+    SCISQL_BOOL const_item = 1;
     if (args->arg_count != 5) {
         snprintf(message, MYSQL_ERRMSG_SIZE, SCISQL_UDF_NAME(s2PtInCircle)
                  " expects exactly 5 arguments");

--- a/src/udfs/s2PtInEllipse.c
+++ b/src/udfs/s2PtInEllipse.c
@@ -110,13 +110,13 @@ typedef struct {
 } _scisql_s2ellipse;
 
 
-SCISQL_API my_bool SCISQL_VERSIONED_FNAME(s2PtInEllipse, _init) (
+SCISQL_API SCISQL_BOOL SCISQL_VERSIONED_FNAME(s2PtInEllipse, _init) (
     UDF_INIT *initid,
     UDF_ARGS *args,
     char *message)
 {
     int i;
-    my_bool const_item = 1, const_ellipse = 1;
+    SCISQL_BOOL const_item = 1, const_ellipse = 1;
     if (args->arg_count != 7) {
         snprintf(message, MYSQL_ERRMSG_SIZE, SCISQL_UDF_NAME(s2PtInEllipse)
                  " expects exactly 7 arguments");

--- a/tools/docs.py
+++ b/tools/docs.py
@@ -439,8 +439,9 @@ def _test(obj):
             except subprocess.CalledProcessError:
                 print("Failed to run documentation example:\n\n%s\n\n" % ex.source,
                       file=sys.stderr)
+                sys.stdout.flush()
                 nfail += 1
-    return nfail 
+    return nfail
 
 
 def run_doc_examples(sections):

--- a/tools/docs.py
+++ b/tools/docs.py
@@ -439,7 +439,6 @@ def _test(obj):
             except subprocess.CalledProcessError:
                 print("Failed to run documentation example:\n\n%s\n\n" % ex.source,
                       file=sys.stderr)
-                sys.stdout.flush()
                 nfail += 1
     return nfail
 

--- a/tools/mysqlversion.py
+++ b/tools/mysqlversion.py
@@ -39,12 +39,12 @@ _MARIADB = "MariaDB"
 # Constraints for compatible MySQL/MariaDB versions
 _DB_CONSTRAINT = {
     _MYSQL: {
-        _MIN_VERSION: (5, 0),
-        _EXACT_VERSION: ['5.1.65', '5.1.73']
+        _MIN_VERSION: (8, 0),
+        _EXACT_VERSION: []
     },
     _MARIADB: {
         _MIN_VERSION: (10, 1),
-        _EXACT_VERSION: ['10.1.9-MariaDB']
+        _EXACT_VERSION: []
     },
 }
 
@@ -60,14 +60,14 @@ def _to_tuple(version):
 
 
 def _parse_version(version):
-    match = re.match(r'([0-9.]+)-MariaDB', version)
-    if match:
+    match = re.match(r'([0-9.]+)(-(.*))?', version)
+    if not match:
+        return None, None
+    nums = _to_tuple(match[1])
+    if match[3] and match[3].startswith(_MARIADB):
         db_name = _MARIADB
-        num_version = match[1]
     else:
         db_name = _MYSQL
-        num_version = version
-    nums = _to_tuple(num_version)
     return db_name, nums
 
 

--- a/tools/templates/sections.xml
+++ b/tools/templates/sections.xml
@@ -425,6 +425,7 @@ SELECT scienceCcdExposureId,
                 Then, run the sciSQL region indexing utility:
         </p>
         <example lang="bash">
+sudo chmod a+r /tmp/scisql_demo_ccds.tsv
 scisql_index -l 10 /tmp/scisql_demo_htmid10.tsv /tmp/scisql_demo_ccds.tsv</example>
         <p>
                 and load the results:

--- a/tools/templates/sections.xml
+++ b/tools/templates/sections.xml
@@ -3,11 +3,11 @@
 <section name="overview" title="Overview">
         <div class="section-docs">
         <p>
-        sciSQL provides science-specific tools and extensions for SQL. Currently, the project
-        contains user defined functions (UDFs) and stored procedures for MySQL in the areas
-        of spherical geometry, statistics, and photometry. The project was motivated by the
-        needs of the <a href="http://www.lsst.org/">Large Synoptic Survey Telescope</a> (LSST)
-        and has been sponsored by LSST and <a href="http://slac.stanford.edu/">SLAC</a> /
+        sciSQL provides science-specific tools and extensions for SQL. Currently, the project contains user
+        defined functions (UDFs) and stored procedures for MySQL or MariaDB in the areas of spherical
+        geometry, statistics, and photometry. The project was motivated by the needs of the <a
+        href="http://www.lsst.org/">Rubin Observatory Legacy Survey of Space and Time</a> (LSST) and has been
+        sponsored by LSST and <a href="http://slac.stanford.edu/">SLAC</a> /
         <a href="http://www.energy.gov/">DOE</a>. sciSQL is distributed under the terms of the
         <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License version 2.0</a>.
         </p>
@@ -34,7 +34,7 @@
 </section>
 
 
-<section name="install" title="Build, Installation &amp; Deployment">
+<section name="install" title="Build, Installation, and Deployment">
         <div class="section-docs">
         <p>
         Read on for instructions on how to configure, build, test, install and uninstall the
@@ -44,10 +44,11 @@
         <dl>
                 <dt><a href="http://www.python.org/download/">Python 2.5.x or later</a></dt>
                 <dt><a href="http://python-future.org/index.html">Python future 0.16 or later</a></dt>
-                <dt><a href="http://dev.mysql.com/downloads/">MySQL server 5.x</a></dt>
-                <dt><a href="http://sourceforge.net/projects/mysql-python/">MySQLdb 1.2.x</a></dt>
+                <dt><a href="https://dev.mysql.com/downloads/mysql/">MySQL server 8.x</a> -or-
+                  <a href="https://mariadb.com/downloads/">MariaDB server 10.x</a></dt>
+                <dt><a href="https://github.com/PyMySQL/mysqlclient">mysqlclient 2.1.x or later</a></dt>
                 <dd>
-                        This is a Python DB API 2.0 implementation for MySQL, and is
+                        This is a Python DB API 2.0 implementation for MySQL/MariaDB, and is
                         required when running the unit tests and uninstalling sciSQL.
                 </dd>
                 <dt><a href="http://www.makotemplates.org/download.html">Mako 0.4 or later</a></dt>
@@ -57,8 +58,8 @@
                 </dd>
         </dl>
         <p>
-        In order to install the UDFs, you will need write permission to the MySQL server
-        plug-in directory, as well as a MySQL account with admin priviledges.
+        In order to install the UDFs, you will need write permission to the MySQL/MariaDB server
+        plug-in directory, as well as a MySQL/MariaDB account with admin priviledges.
         </p>
 
         <h3 class="warning">Databases reserved for sciSQL use</h3>
@@ -88,13 +89,15 @@
         <p>
         Run <tt>./configure</tt> from the top-level sciSQL directory. Passing <tt>--help</tt>
         will yield a list of configuration options. Here are the ones most likely to require
-        tweaking:
+        tweaking if <tt>./configure</tt> doesn't work straight out of the box on your system:
         </p>
         <dl>
-                <dt><tt>--prefix</tt></dt>
-                <dd>Set this to the top-level directory which will contains sciSQL tools and shared library</dd>
+                <dt><tt>--mysql-dir</tt></dt>
+                <dd>Set this to the top-level of the MySQL/MariaDB server install tree</dd>
+                <dt><tt>--mysql-config</tt></dt>
+                <dd>Point to <tt>mysql_config</tt> or <tt>mariadb_config</tt> configuration tool</dd>
                 <dt><tt>--mysql-includes</tt></dt>
-                <dd>Set this to the top-level directory where the MySQL header files are located</dd>
+                <dd>Point to MySQL/MariaDB headers (<tt>mysql.h</tt> and dependents)</dd>
                 <dt><tt>--scisql-prefix</tt></dt>
                 <dd>
                 This string will be used as a prefix for all sciSQL UDF and stored procedure
@@ -104,26 +107,16 @@
         </dl>
         <p>
         If you wish to build/install only the sciSQL client utilities and documentation,
-        run configure with the --client-only option. In this case, a MySQL server or
+        run configure with the <tt>--client-only</tt> option. In this case, a MySQL/MariaDB server or
         client install is not required, the only executable generated is scisql_index
         (a utility which generates HTM indexes for tables of circles or polygons stored
         in tab-separated-value format).
         </p>
 
-        <h3>Build/Install</h3>
+        <h3>Build</h3>
         <p>
-        sciSQL is built, installed, and uninstalled with the usual <tt>make</tt>,
-        <tt>make install</tt>, and <tt>make uninstall</tt> commands.
-        </p>
-        <p>
-        The <tt>build</tt> command also automatically run the sciSQL unit tests.
-        You can re-run the tests anytime with <tt>make test</tt>.
-        </p>
-        <p>
-        The <tt>install</tt> command will he sciSQL UDFs, stored procedures, and
-        databases (including the scisql_demo database). It will also automatically
-        run the sciSQL unit tests.
-        You can re-run the tests anytime with <tt>make test</tt>.
+        sciSQL is built and staged with the usual <tt>make</tt> and <tt>make install</tt>
+        commands.
         </p>
         <p>
         You may wish to regenerate the HTML documentation if you've chosen a
@@ -132,36 +125,40 @@
         To do this, run <tt>make html_docs</tt>.
         </p>
 
-        <h3>Deploying sciSQL in a MySQL instance</h3>
-        <p> Assuming you've installed scisql in $PREFIX, update your PATH and PYTHONPATH as described below:
+        <h3>Deploying sciSQL in a MySQL/MariaDB instance</h3>
+        <p> Assuming you've installed scisql in <tt>$PREFIX</tt>, update your <tt>PATH</tt> and
+        <tt>PYTHONPATH</tt> as described below:
         <example lang="bash">
 export PATH="&#36;PREFIX/bin:&#36;PATH"
 export PYTHONPATH="&#36;PREFIX/python:&#36;PATH"</example>
-        Check that your have access to a local MySQL server instance and run <tt>scisql-deploy.py</tt>. Passing <tt>--help</tt>
-        will yield a list of configuration options. Here are the ones most likely to require
+        Check that you have access to a local server instance and run <tt>scisql-deploy.py</tt>. Passing
+        <tt>--help</tt> will yield a list of configuration options. Here are the ones most likely to require
         tweaking:
         </p>
         <dl>
                 <dt><tt>--mysql-user</tt></dt>
-                <dd>Set this to the name of a MySQL admin user. Default to 'root'</dd>
+                <dd>Set this to the name of a MySQL/MariaDB admin user; defaults to <tt>root</tt></dd>
+                <dt><tt>--mysql-bin</tt></dt>
+                <dd>Point to the <tt>mysql</tt> or <tt>mariadb</tt> command-line client</dd>
                 <dt><tt>--mysql-socket</tt></dt>
-                <dd>Set this to the name of the MySQL server UNIX socket file</dd>
+                <dd>Point to the MySQL/MariaDB server UNIX socket file</dd>
                 <dt><tt>--verbose</tt></dt>
-                <dd>Verbose level, possible value are FATAL, ERROR, WARN, INFO, DEBUG</dd>
+                <dd>Verbosity level; possible value are FATAL, ERROR, WARN, INFO, DEBUG</dd>
         </dl>
         <p>
-        You will be prompted for the MySQL admin user password during configuration.
+        You will be prompted for the MySQL/MariaDB admin user password during configuration.
         If you run <tt>scisql-deploy.py</tt> in a script, you can
         use standard input, for example via a pipe, for providing this password.
         Connection details, including this password, are stored in a temporary directory in a file named
         <tt>my-client.cnf</tt> using the MySQL options file format. This temporary file is removed at the end
-        of the process, unless you set the verbose level to DEBUG
+        of the process, unless you set the verbose level to DEBUG.
         </p>
         <p>
         The <tt>scisql-deploy.py</tt> command will CREATE the sciSQL UDFs, stored procedures, and
         databases (including the scisql_demo database). It will also automatically
-        run the sciSQL integration tests, which check that sciSQL is correctly deployed in MySQL.
-        You can re-run the tests anytime using <tt>--test</tt> option.
+        run the sciSQL integration tests, which check that sciSQL is correctly deployed.
+        You can re-run the tests anytime by invoking <tt>scisql-deploy.py</tt> with the 
+        <tt>--test</tt> option.
         </p>
         <p>
         Finally, note that after installation each UDF will be available under two
@@ -171,17 +168,18 @@ export PYTHONPATH="&#36;PREFIX/python:&#36;PATH"</example>
         </p>
         <ul><li>foo_bar</li><li>foo_bar_1_2_3</li></ul>
         <p>
-        The <tt>uninstall</tt> command will drop the versioned sciSQL UDFs and stored
+        Invoking <tt>scisql-deploy.py</tt> with the <tt>--undeploy</tt> option
+        will drop the versioned sciSQL UDFs and stored
         procedures. It will also drop the unversioned UDFs/procedures, but only
         if the unversioned UDF/procedure was created by the version of
         sciSQL being uninstalled. As a consequence, it is possible to have
         multiple versions of sciSQL installed at the same time, and the behavior
-        of two versions can be compared from within a single MySQL instance.
+        of two versions can be compared from within a single MySQL/MariaDB instance.
         An unversioned name will resolve to the most recently installed versioned
         name.
         </p>
         <p>
-        The uninstall command will also drop the scisql_demo database.
+        An updeploy will also drop the scisql_demo database.
         </p>
 
         <h3>Rebuilding sciSQL</h3>
@@ -191,47 +189,41 @@ export PYTHONPATH="&#36;PREFIX/python:&#36;PATH"</example>
         do the following from the top-level sciSQL directory:
         </p>
         <dl>
-        <dt><tt>scisql-deploy.py --mysql-socket=/path/to/mysql/sock --undeploy</tt></dt><dd>Uninstalls the UDFs and stored procedures named <tt>foo_*</tt>.</dd>
-        <dt><tt>make uninstall</tt></dt><dd>Empty sciSQL install directory (i.e. $PREFIX)</dd>
+        <dt><tt>scisql-deploy.py ... --undeploy</tt></dt><dd>Uninstalls the UDFs and stored procedures named <tt>foo_*</tt>.</dd>
         <dt><tt>make distclean</tt></dt><dd>Removes all build products and configuration files.</dd>
         <dt><tt>configure --scisql-prefix=bar_ ...</tt></dt><dd>Reconfigures sciSQL (sets new name prefix).</dd>
         <dt><tt>make</tt></dt><dd>Rebuilds sciSQL.</dd>
-        <dt><tt>make install</tt></dt><dd>Reinstalls sciSQL.</dd>
-        <dt><tt>scisql-deploy.py --mysql-socket=/path/to/mysql/sock</tt></dt><dd>Deploy sciSQL in your MySQL instance.</dd>
+        <dt><tt>make install</tt></dt><dd>Restages sciSQL.</dd>
+        <dt><tt>scisql-deploy.py ...</tt></dt><dd>Redeploys sciSQL</dd>
         </dl>
         <p>
-        No MySQL restart is required. Note that multiple installations of the same
+        No MySQL/MariaDB restart is required. Note that multiple installations of the same
         version of sciSQL with different UDF/procedure name prefixes can coexist on
-        a single MySQL instance.
+        a single MySQL/MariaDB instance.
         </p>
 
-
-        <h3>MySQL server restarts</h3>
+        <h3>MySQL/MariaDB server restarts</h3>
         <p>
         Installing different versions of sciSQL, or multiple copies of the same
-        version with different UDF/procedure name prefixes, does not require a MySQL
+        version with different UDF/procedure name prefixes, does not require a
         server restart.
         </p>
         <p>
         Only sciSQL developers should need to perform restarts. They are
         required when changing the name of a UDF without changing the name of the
-        shared library installed into the MySQL plugin directory. In this case,
+        shared library installed into the server plugin directory. In this case,
         an attempt to install the updated shared library will sometimes result in
-        MySQL reporting that it cannot find symbol names that are actually
-        present. This is presumably due to MySQL server and/or OS level caching
-        effects, and restarting MySQL resolves the problem.
+        MySQL/MariaDB reporting that it cannot find symbol names that are actually
+        present. This is presumably due to server and/or OS level caching
+        effects, and restarting the server resolves the problem.
         </p>
 
         <h3>Reporting bugs and getting help</h3>
         <p>
         If you encounter test-case failures, or think you've identified a
-        bug in the sciSQL code, please file a report here:
+        bug in the sciSQL code, or would just like to ask a question, please
+        <a href="https://github.com/smonkewitz/scisql/issues">submit an issue</a>.
         </p>
-        <p><a href="https://bugs.launchpad.net/scisql/+filebug">https://bugs.launchpad.net/scisql/+filebug</a></p>
-        <p>
-        For other help or inquiries, submit your questions here:
-        </p>
-        <p><a href="https://answers.launchpad.net/scisql/+addquestion">https://answers.launchpad.net/scisql/+addquestion</a></p>
         </div>
 </section>
 

--- a/tools/undeploy.py
+++ b/tools/undeploy.py
@@ -105,11 +105,11 @@ def dropProc(cursor, proc, prefix, vsuffix):
                    (prefix, proc, vsuffix))
     # Drop unversioned shim if it calls the versioned procedure defined
     # by this version of sciSQL
-    cursor.execute('''SELECT body_utf8 FROM mysql.proc
-                      WHERE name = "%s%s" AND db = "scisql"''' % (prefix, proc))
+    cursor.execute('''SELECT routine_definition FROM information_schema.routines
+                      WHERE routine_name = "%s%s" AND routine_schema = "scisql"''' % (prefix, proc))
     rows = cursor.fetchall()
     if len(rows) == 1:
-        body = str(rows[0][0].decode())
+        body = rows[0][0]
         pat = r'^\s*BEGIN\s+CALL\s+%s%s%s\s*\(.*\)\s*;\s*END\s*$' % (
               prefix, proc, vsuffix)
         if re.match(pat, body):


### PR DESCRIPTION
It looks like MySQL builds had been broken for a bit.  Decided to port forward to MySQL 8.0 while fixing, since it's been out since April 2018, and this was a bit of a pain.

MySQL 8.0 defaults to very conservative permissions wrt. `OUTFILE` and `LOCAL INFILE`; I guess that's a good thing but it took some extra shenanigans with the github action and the htm test sequence itself to work around this (and debugging github actions is itself pretty trying.)

In any case, CI builds of docs, MariaDB and MySQL are working with this, and it should help keep things from silently breaking again as we go forward...